### PR TITLE
Add basic example git-flow rulesets

### DIFF
--- a/rulesets/gitflow/README.md
+++ b/rulesets/gitflow/README.md
@@ -1,0 +1,46 @@
+# GitHub Rulesets
+
+These json files represent [GitHub Rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets).
+
+Each is created by exporting an existing ruleset in effect in this repo.
+
+# Export
+
+To create a ruleset file from an existing ruleset (usually created through the web UI):
+
+- In Repo Settings, on the sidebar, go to "Rules" -> "Rulesets".
+- Find the ruleset you want to export.
+- In the "..." (three dots) menu, "Export Ruleset".
+
+# Import
+
+NOTE: If you are updating an existing ruleset, see "Update" below.
+
+To import a new ruleset (from a file) into the repo's settings:
+
+- In Repo Settings, on the sidebar, go to "Rules" -> "Rulesets".
+- Click the green "New Ruleset" -> "Import a ruleset".
+- Navigate to a JSON file (on your local machine) that defines the ruleset you want.
+- Scroll to bottom of page and **"Create"**
+
+# Update
+
+If you want to alter an existing ruleset (such as adding required checks, see [PR#189](https://github.com/RMI/pbtar/pull/189)):
+
+- In Repo Settings, on the sidebar, go to "Rules" -> "Rulesets".
+- Find the ruleset you want to update.
+- Click on the ruleset name (not three-dots) to see rulest definition in the WebUI.
+  - Rename the ruleset (suggestion `rule-name` -> `rule-name-old`)
+  - Set "Enforcement Status" to "Disabled"
+  - Scroll to bottom of page and **"Save Changes"**
+- Return to "Rulesets" main page, and import the updated definiton (see above, "Import").
+- Repeat if changing multiple rulesets
+- _(Testing):_
+  - Trigger an empty commit: `git commit -m "Trigger CI" --allow-empty` and push to trigger checking action
+  - The action **should fail**.
+  - You should see in the `diff`:
+    - You will also see the `*_old` actions as having no comparisons.
+  - If there are no differences in the ruleset you updated, then it has imported as expected, and you can delete the `*_old` ruleset in the Repo settings.
+    - "Rulesets" -> "`*_old`" -> "..." \_. "Delete ruleset".
+  - Trigger a new empty commit and push.
+  - There should be no diffs, and actions run cleanly with new rulesets in effect.

--- a/rulesets/gitflow/gitflow-main.json
+++ b/rulesets/gitflow/gitflow-main.json
@@ -1,0 +1,42 @@
+{
+  "name": "gitflow-main",
+  "target": "branch",
+  "source_type": "Repository",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": ["~DEFAULT_BRANCH", "refs/heads/main"]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "creation"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true,
+        "required_review_thread_resolution": false,
+        "automatic_copilot_code_review_enabled": true,
+        "allowed_merge_methods": ["squash"]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "pull_request"
+    }
+  ]
+}

--- a/rulesets/gitflow/gitflow-next.json
+++ b/rulesets/gitflow/gitflow-next.json
@@ -1,0 +1,50 @@
+{
+  "name": "gitflow-next",
+  "target": "branch",
+  "source_type": "Repository",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": ["refs/heads/next"]
+    }
+  },
+  "rules": [
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "creation"
+    },
+    {
+      "type": "update"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true,
+        "required_review_thread_resolution": true,
+        "automatic_copilot_code_review_enabled": false,
+        "allowed_merge_methods": ["squash"]
+      }
+    },
+    {
+      "type": "deletion"
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 2,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    },
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ]
+}

--- a/rulesets/gitflow/gitflow-production.json
+++ b/rulesets/gitflow/gitflow-production.json
@@ -1,0 +1,47 @@
+{
+  "name": "gitflow-production",
+  "target": "branch",
+  "source_type": "Repository",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": ["refs/heads/production"]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "creation"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 2,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true,
+        "required_review_thread_resolution": true,
+        "automatic_copilot_code_review_enabled": false,
+        "allowed_merge_methods": ["merge", "squash"]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 2,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "pull_request"
+    },
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "pull_request"
+    }
+  ]
+}


### PR DESCRIPTION
Add example rulesets for git-flow(-ish) workflow.

these represent the branch protections as used in [RMI/pbtar](https://github.com/RMI/pbtar), with the required checks removed.