### PR TITLE
Update forbidden patterns to permit `TK` (single)

### DIFF
--- a/actions/admin/forbidden-patterns/default_patterns.txt
+++ b/actions/admin/forbidden-patterns/default_patterns.txt
@@ -9,7 +9,7 @@
 (^|[^[:alpha:]])XXX([^[:alpha:]]|$)
 
 # --- Editorial placeholders often left in docs/UI copy
-(^|[^[:alpha:]])TK(TK)?([^[:alpha:]]|$)
+(^|[^[:alpha:]])TKTK(TK)?([^[:alpha:]]|$)
 lorem[[:space:]]+ipsum
 
 # --- “Finish me” config placeholders


### PR DESCRIPTION
Prevent the action from flagging a single `TK` or `tk` as forbidden, since it's the ISO 3166-1 Alpha-2 Code for Tokelau, a territory of New Zealand in the South Pacific