### PR TITLE
fix(rulesets-check): Acknowledge update_allows_fetch_and_merge

### DIFF
--- a/actions/admin/rulesets-check/schema/acknowledged-untracked.json
+++ b/actions/admin/rulesets-check/schema/acknowledged-untracked.json
@@ -9,6 +9,7 @@
     "current_user_can_bypass",
     "bypass_actors",
     "source",
-    "source_type"
+    "source_type",
+    "rules.update.parameters.update_allows_fetch_and_merge"
   ]
 }


### PR DESCRIPTION
GitHub added the update_allows_fetch_and_merge parameter to the `update` ruleset rule type, causing the nightly schema-coverage check to fail (neither tracked nor acknowledged).

It's a fork-sync carve-out ("Branch can pull changes from its upstream repository") that only matters for forks. All four consumer repos with a gitflow-next-pr ruleset (stitch, tpr, stitch-etl-poc, rmi-webapp-template) have the update rule's parameters set to null, and none is a fork.

Acknowledge rather than track it: tracking would mismatch every repo's live `parameters: null` and fail all consumer PR checks until each live ruleset is manually updated, for a knob none of them uses.
